### PR TITLE
Fix custom element definition error

### DIFF
--- a/voxeland/index.html
+++ b/voxeland/index.html
@@ -5,6 +5,23 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
+    <script>
+      (function () {
+        var ce = window.customElements;
+        if (!ce || !ce.define || !ce.get) return;
+        var origDefine = ce.define.bind(ce);
+        ce.define = function (name, constructor, options) {
+          if (ce.get(name)) return; // Avoid duplicate registration
+          try {
+            origDefine(name, constructor, options);
+          } catch (err) {
+            var msg = String(err || '');
+            if (msg.indexOf('has already been defined') !== -1) return;
+            throw err;
+          }
+        };
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Add a guard for `customElements.define` to prevent "already defined" errors and resolve the black screen issue.

The application was crashing due to a `custom element with name 'mce-autosize-textarea' has already been defined` error, leading to a black screen. This fix ensures that custom elements are not redefined, allowing the application to load correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9945be5-1944-40c9-89ff-fd84ef1eb87b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9945be5-1944-40c9-89ff-fd84ef1eb87b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Bug Fixes:
- Override customElements.define to check for existing registrations and suppress “has already been defined” exceptions