### PR TITLE
Fix black screen and custom element error

### DIFF
--- a/voxeland/src/render/Renderer.ts
+++ b/voxeland/src/render/Renderer.ts
@@ -11,13 +11,17 @@ export class Renderer {
     this.camera = new THREE.PerspectiveCamera(fov, width / height, 0.1, 1000);
     this.renderer = new THREE.WebGLRenderer({ antialias: false, powerPreference: 'high-performance' });
     this.renderer.setSize(width, height);
+    // Ensure crisp rendering and a visible sky background instead of default black
+    this.renderer.setPixelRatio(window.devicePixelRatio || 1);
+    this.renderer.setClearColor(0x87ceeb, 1); // sky blue
+    this.scene.background = new THREE.Color(0x87ceeb);
     container.appendChild(this.renderer.domElement);
 
     this.scene.fog = new THREE.FogExp2(0x87ceeb, 0.012);
 
-    const ambient = new THREE.AmbientLight(0xffffff, 0.5);
+    const ambient = new THREE.AmbientLight(0xffffff, 0.6);
     this.scene.add(ambient);
-    const dir = new THREE.DirectionalLight(0xffffff, 0.6);
+    const dir = new THREE.DirectionalLight(0xffffff, 0.8);
     dir.position.set(1, 2, 1);
     this.scene.add(dir);
 

--- a/voxeland/vite.config.ts
+++ b/voxeland/vite.config.ts
@@ -9,4 +9,9 @@ export default defineConfig({
   build: {
     target: 'esnext',
   },
+  server: {
+    hmr: {
+      overlay: false,
+    },
+  },
 });


### PR DESCRIPTION
Disable Vite HMR overlay to fix custom element redefinition error and add visible sky background with adjusted lighting.

The Vite HMR overlay was causing a `Custom element already defined` error, which prevented the main application JavaScript from fully initializing and rendering the world. Disabling it resolves this conflict. Additionally, a default sky background and slightly brighter lighting were added to ensure the scene is visible even before terrain chunks are loaded.

---
<a href="https://cursor.com/background-agent?bcId=bc-538e286f-9707-40a1-ba88-d3d5bda0ad3d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-538e286f-9707-40a1-ba88-d3d5bda0ad3d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Disable Vite’s HMR overlay to prevent custom element redefinition errors and improve scene visibility by adding a sky-blue background and brighter lighting.

Bug Fixes:
- Disable Vite HMR overlay to fix the “Custom element already defined” error.

Enhancements:
- Set renderer pixel ratio for crisper output.
- Add sky-blue clear color and scene background.
- Increase ambient and directional light intensities for better visibility.