### PR TITLE
Debug and fix world generation

### DIFF
--- a/voxeland/src/app/Game.ts
+++ b/voxeland/src/app/Game.ts
@@ -6,6 +6,7 @@ import { InputManager } from '../input/InputManager';
 import { PlayerController } from '../physics/PlayerController';
 import { ChunkManager } from '../world/ChunkManager';
 import { BlockId } from '../world/BlockId';
+import { debugState } from '../core/Debug';
 
 export type GameOptions = {
   container: HTMLElement;
@@ -56,6 +57,13 @@ export class Game {
         camera.rotation.set(this.player.pitch, this.player.yaw, 0, 'ZYX');
         this.chunks.updateAround(this.player.position);
         this.chunks.unloadFar(this.player.position);
+
+        // Debug updates
+        debugState.player.x = this.player.position.x;
+        debugState.player.y = this.player.position.y;
+        debugState.player.z = this.player.position.z;
+        debugState.player.yaw = this.player.yaw;
+        debugState.player.pitch = this.player.pitch;
       },
     });
 

--- a/voxeland/src/core/Debug.ts
+++ b/voxeland/src/core/Debug.ts
@@ -1,0 +1,27 @@
+export type DebugState = {
+  player: { x: number; y: number; z: number; yaw: number; pitch: number };
+  chunks: {
+    generated: number;
+    meshed: number;
+    activeChunkCount: number;
+    activeMeshCount: number;
+    lastGen: { cx: number; cz: number } | null;
+    lastMesh: { cx: number; cz: number } | null;
+  };
+};
+
+export const debugState: DebugState = {
+  player: { x: 0, y: 0, z: 0, yaw: 0, pitch: 0 },
+  chunks: {
+    generated: 0,
+    meshed: 0,
+    activeChunkCount: 0,
+    activeMeshCount: 0,
+    lastGen: null,
+    lastMesh: null,
+  },
+};
+
+// Expose to window for quick inspection in devtools
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(globalThis as any).__dbg = debugState;

--- a/voxeland/src/ui/HUD.tsx
+++ b/voxeland/src/ui/HUD.tsx
@@ -1,4 +1,7 @@
+import { debugState } from '../core/Debug';
+
 export function HUD() {
+  const d = debugState;
   return (
     <div style={{ position: 'absolute', left: 0, top: 0, right: 0, bottom: 0, pointerEvents: 'none' }}>
       <div
@@ -17,6 +20,15 @@ export function HUD() {
           borderRadius: 2,
         }}
       />
+      {/* debug overlay */}
+      <div style={{ position: 'absolute', top: 8, left: 8, padding: '6px 8px', background: 'rgba(0,0,0,0.45)', color: '#e0f7fa', fontFamily: 'monospace', fontSize: 12, borderRadius: 4 }}>
+        <div>pos: {d.player.x.toFixed(2)} {d.player.y.toFixed(2)} {d.player.z.toFixed(2)}</div>
+        <div>rot: yaw {d.player.yaw.toFixed(2)} pitch {d.player.pitch.toFixed(2)}</div>
+        <div>chunks: gen {d.chunks.generated} mesh {d.chunks.meshed}</div>
+        <div>active: chunks {d.chunks.activeChunkCount} meshes {d.chunks.activeMeshCount}</div>
+        <div>last: gen {d.chunks.lastGen ? `${d.chunks.lastGen.cx},${d.chunks.lastGen.cz}` : '-'}</div>
+        <div>last: mesh {d.chunks.lastMesh ? `${d.chunks.lastMesh.cx},${d.chunks.lastMesh.cz}` : '-'}</div>
+      </div>
       <div style={{ position: 'absolute', bottom: 16, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 6 }}>
         {new Array(9).fill(0).map((_, i) => (
           <div key={i} style={{ width: 36, height: 36, border: '2px solid rgba(255,255,255,0.7)', background: 'rgba(0,0,0,0.2)', borderRadius: 4 }} />

--- a/voxeland/src/workers/mesher.worker.ts
+++ b/voxeland/src/workers/mesher.worker.ts
@@ -19,6 +19,9 @@ export type MeshResponse = {
   uvs: ArrayBuffer;
   colors: ArrayBuffer;
   indices: ArrayBuffer;
+  // debug
+  solidBlocks: number;
+  faceCount: number;
 };
 
 const DIRS = [
@@ -99,6 +102,9 @@ function buildMesh(
     return voxels[idx(x, y, z)] as BlockId;
   };
 
+  let solidBlocks = 0;
+  let faceCount = 0;
+
   const pushFace = (face: number, x: number, y: number, z: number, tileIndex: number, lightness: number) => {
     const base = positions.length / 3;
     const verts = FACES[face];
@@ -120,6 +126,7 @@ function buildMesh(
       colors.push(lightness, lightness, lightness);
     }
     indices.push(base, base + 1, base + 2, base, base + 2, base + 3);
+    faceCount++;
   };
 
   for (let y = 0; y < CHUNK_SIZE_Y; y++) {
@@ -127,6 +134,7 @@ function buildMesh(
       for (let x = 0; x < CHUNK_SIZE_X; x++) {
         const id = voxels[idx(x, y, z)] as BlockId;
         if (id === BlockId.Air) continue;
+        solidBlocks++;
         const def = BLOCKS[id];
         for (let f = 0; f < 6; f++) {
           const nx = x + DIRS[f].d[0];
@@ -149,6 +157,8 @@ function buildMesh(
     uvs: new Float32Array(uvs).buffer,
     colors: new Float32Array(colors).buffer,
     indices: new Uint32Array(indices).buffer,
+    solidBlocks,
+    faceCount,
   };
 }
 

--- a/voxeland/src/world/ChunkManager.ts
+++ b/voxeland/src/world/ChunkManager.ts
@@ -5,6 +5,7 @@ import { computeSunlight } from './Lighting';
 import { BlockId } from './BlockId';
 import { putChunk, getChunk } from './SaveStore';
 import type { WorldId } from '../core/Types';
+import { debugState } from '../core/Debug';
 
 export type ChunkMeshData = {
   mesh: THREE.Mesh;
@@ -60,6 +61,7 @@ export class ChunkManager {
       this.chunks.set(k, chunk);
       this.requestMesh(chunk);
       this.updateLRU(k);
+      debugState.chunks.activeChunkCount = this.chunks.size;
       return;
     }
     // Request generation
@@ -71,14 +73,19 @@ export class ChunkManager {
     const k = this.key(cx, cz);
     const chunk = new Chunk(cx, cz);
     chunk.voxels.set(new Uint16Array(voxels));
+    // Put into map before computing light so intra-chunk queries work as expected
+    this.chunks.set(k, chunk);
     // compute sunlight
     const get = (x: number, y: number, z: number) => this.getBlock(x, y, z);
     computeSunlight(chunk, get);
-    this.chunks.set(k, chunk);
     this.updateLRU(k);
     // persist
     putChunk({ key: { worldId: this.opts.worldId, cx, cz }, voxels: chunk.voxels.buffer.slice(0), light: chunk.light.buffer.slice(0), version: 1 });
     this.requestMesh(chunk);
+    debugState.chunks.generated++;
+    debugState.chunks.lastGen = { cx, cz };
+    debugState.chunks.activeChunkCount = this.chunks.size;
+    console.debug('[generated]', { cx, cz });
   }
 
   private requestMesh(chunk: Chunk) {
@@ -91,7 +98,7 @@ export class ChunkManager {
     });
   }
 
-  private onMeshed(data: { cx: number; cz: number; positions: ArrayBuffer; normals: ArrayBuffer; uvs: ArrayBuffer; colors: ArrayBuffer; indices: ArrayBuffer }) {
+  private onMeshed(data: { cx: number; cz: number; positions: ArrayBuffer; normals: ArrayBuffer; uvs: ArrayBuffer; colors: ArrayBuffer; indices: ArrayBuffer; solidBlocks: number; faceCount: number }) {
     const { cx, cz } = data;
     const k = this.key(cx, cz);
     const positions = new Float32Array(data.positions);
@@ -121,6 +128,11 @@ export class ChunkManager {
 
     this.meshes.set(k, { mesh, bounds });
     this.opts.scene.add(mesh);
+    debugState.chunks.meshed++;
+    debugState.chunks.lastMesh = { cx, cz };
+    debugState.chunks.activeMeshCount = this.meshes.size;
+    // quick console for visibility when running dev
+    console.debug('[meshed]', { cx, cz, solidBlocks: data.solidBlocks, faceCount: data.faceCount });
   }
 
   unloadFar(center: THREE.Vector3) {
@@ -130,6 +142,7 @@ export class ChunkManager {
         this.unloadByKey(k);
       }
     }
+    debugState.chunks.activeMeshCount = this.meshes.size;
   }
 
   private unloadByKey(k: string) {


### PR DESCRIPTION
Adds debug overlay and console logging, and fixes a critical bug in chunk lighting computation.

The `ChunkManager` previously computed sunlight before adding the newly generated chunk to its internal map. This caused `getBlock` calls within `computeSunlight` to incorrectly return `Air` for blocks within the same chunk, leading to incorrect lighting calculations. The fix ensures the chunk is added to the map before lighting is computed.

---
<a href="https://cursor.com/background-agent?bcId=bc-697e18bf-de31-4973-9f37-6a437f0ef806">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-697e18bf-de31-4973-9f37-6a437f0ef806">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Fix incorrect chunk lighting by registering newly generated chunks before computing sunlight and add comprehensive runtime debugging including an on-screen HUD, console logs, and a global debugState tracking player and chunk metrics.

New Features:
- Add a debug overlay HUD displaying player position, rotation, chunk generation/meshing counts, active counts, and last actions

Bug Fixes:
- Ensure generated chunks are inserted into the chunk map before computing sunlight to correct intra-chunk lighting errors

Enhancements:
- Introduce a global debugState for tracking player and chunk statistics and expose it on window
- Extend mesher worker responses with solid block and face count metrics and log debug events during chunk generation and meshing